### PR TITLE
Add `attributes` and `tags` to the 'label' module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 resource "aws_elastic_beanstalk_application" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,18 @@ variable "name" {
 variable "description" {
   default = ""
 }
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Added `attributes` and `tags` to the 'label' module


## Why

* So we could assign arbitrary tags to the AWS resources

