### PR TITLE
Add `tags` to `aws_elastic_beanstalk_application`. Add `appversion_lifecycle` block

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| appversion_lifecycle_delete_source_from_s3 | Whether to delete application versions from S3 source | bool | `false` | no |
+| appversion_lifecycle_max_count | The max number of application versions to keep | number | `1000` | no |
+| appversion_lifecycle_service_role_arn | The service role ARN to use for application version cleanup. If left empty, the `appversion_lifecycle` block will not be created | string | `` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Elastic Beanstalk Application description | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,6 +2,9 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| appversion_lifecycle_delete_source_from_s3 | Whether to delete application versions from S3 source | bool | `false` | no |
+| appversion_lifecycle_max_count | The max number of application versions to keep | number | `1000` | no |
+| appversion_lifecycle_service_role_arn | The service role ARN to use for application version cleanup. If left empty, the `appversion_lifecycle` block will not be created | string | `` | no |
 | attributes | Additional attributes (e.g. `1`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | description | Elastic Beanstalk Application description | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,24 @@ module "label" {
   tags       = var.tags
 }
 
+locals {
+  // Remove `Name` tag from the map of tags because Elastic Beanstalk generates the `Name` tag automatically
+  // and if it is provided, terraform tries to recreate the application on each `plan/apply`
+  // https://github.com/terraform-providers/terraform-provider-aws/issues/3963
+  tags = { for t in keys(module.label.tags) : t => module.label.tags[l] if t != "Name" }
+}
+
 resource "aws_elastic_beanstalk_application" "default" {
   name        = module.label.id
   description = var.description
-  tags        = module.label.tags
+  tags        = local.tags
+
+  dynamic "appversion_lifecycle" {
+    for_each = var.appversion_lifecycle_service_role_arn != "" ? ["true"] : []
+    content {
+      service_role          = var.appversion_lifecycle_service_role_arn
+      max_count             = var.appversion_lifecycle_max_count
+      delete_source_from_s3 = var.appversion_lifecycle_delete_source_from_s3
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -11,4 +11,5 @@ module "label" {
 resource "aws_elastic_beanstalk_application" "default" {
   name        = module.label.id
   description = var.description
+  tags        = module.label.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,3 +38,21 @@ variable "description" {
   default     = ""
   description = "Elastic Beanstalk Application description"
 }
+
+variable "appversion_lifecycle_service_role_arn" {
+  type        = string
+  description = "The service role ARN to use for application version cleanup. If left empty, the `appversion_lifecycle` block will not be created"
+  default     = ""
+}
+
+variable "appversion_lifecycle_max_count" {
+  type        = number
+  default     = 1000
+  description = "The max number of application versions to keep"
+}
+
+variable "appversion_lifecycle_delete_source_from_s3" {
+  type        = bool
+  default     = false
+  description = "Whether to delete application versions from S3 source"
+}


### PR DESCRIPTION
## what
* Add `tags` to `aws_elastic_beanstalk_application`
* Add `appversion_lifecycle` block

## why
* `aws_elastic_beanstalk_application` supports tags (but the `Name tag needs to be removed, see https://github.com/terraform-providers/terraform-provider-aws/issues/3963

* `aws_elastic_beanstalk_application` now supports `appversion_lifecycle`

## related
* Closes #10 
* Closes #11 
