### PR TITLE
Removes the "Namespace" tag due to EBS limitation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,8 +11,9 @@ module "label" {
 locals {
   // Remove `Name` tag from the map of tags because Elastic Beanstalk generates the `Name` tag automatically
   // and if it is provided, terraform tries to recreate the application on each `plan/apply`
+  // `Namespace` should be removed as well since any string that contains `Name` forces recreation
   // https://github.com/terraform-providers/terraform-provider-aws/issues/3963
-  tags = { for t in keys(module.label.tags) : t => module.label.tags[t] if t != "Name" }
+  tags = { for t in keys(module.label.tags) : t => module.label.tags[t] if t != "Name" && t != "Namespace" }
 }
 
 resource "aws_elastic_beanstalk_application" "default" {


### PR DESCRIPTION
Including the "Namespace" tag to the beanstalk-application resource required a change for each apply as the tag is never applied. Removing that tag causes the beanstalk-application to avoid the consistent "change" to the resource on each apply. 

Copy / pasta from https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/commit/8505a0a7411dc2f4ad613a0b544e071c918ed1a3