### PR TITLE
Upgrading from AWS Provider version 2

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
* Upgraded AWS provider version

## why
* Provider version 2 fixed version doesn't let developers to upgrade to Provider 3

## references
* Tested in Segence production systems, deployment successful, EB app running no problem

