### PR TITLE
Fixes `enabled` input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,13 @@ locals {
   # and if it is provided, terraform tries to recreate the application on each `plan/apply`
   # `Namespace` should be removed as well since any string that contains `Name` forces recreation
   # https://github.com/terraform-providers/terraform-provider-aws/issues/3963
-  tags = { for t in keys(module.this.tags) : t => module.this.tags[t] if t != "Name" && t != "Namespace" }
+  tags    = { for t in keys(module.this.tags) : t => module.this.tags[t] if t != "Name" && t != "Namespace" }
+  enabled = module.this.enabled
 }
 
 resource "aws_elastic_beanstalk_application" "default" {
+  count = local.enabled ? 1 : 0
+
   name        = module.this.id
   description = var.description
   tags        = local.tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "elastic_beanstalk_application_name" {
-  value       = aws_elastic_beanstalk_application.default.name
+  value       = join("", aws_elastic_beanstalk_application.default[*].name)
   description = "Elastic Beanstalk Application name"
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

- Fixes currently broken behavior when `enabled = false`

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

- `enabled` is listed as a supported input but setting it to `false` results in an apply-time error:
```log
│ Error: creating Elastic Beanstalk Application (): InvalidParameter: 1 validation error(s) found.
│ - minimum field size of 1, CreateApplicationInput.ApplicationName.
│ 
│ 
│   with module.elastic_beanstalk_application.aws_elastic_beanstalk_application.default,
│   on .terraform/modules/elastic_beanstalk_application/main.tf line 9, in resource "aws_elastic_beanstalk_application" "default":
│    9: resource "aws_elastic_beanstalk_application" "default" {
│ 
```
- The `aws_elastic_beanstalk_application` resource should not be created when `enabled = false` but nothing within the resource references `enabled`

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
This fix handles `enabled` in the same way [cloudposse/elastic-beanstalk-environment](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/blob/main/main.tf#L1-L2) does
