### PR TITLE
feat(): Avoid IAM service role name conflicts when used with terraform-aws-elastic-beanstalk-environment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "service" {
 resource "aws_iam_role" "default" {
   count = local.enabled && var.create_lifecycle_service_role ? 1 : 0
 
-  name               = "${module.this.id}-eb-service"
+  name               = "${module.this.id}-eb-appversion-lifecycle-service"
   assume_role_policy = join("", data.aws_iam_policy_document.service[*].json)
   tags               = module.this.tags
 }


### PR DESCRIPTION
## what

When this module is used together with [cloudposse/terraform-aws-elastic-beanstalk-environment](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment), the environment module already creates an Elastic Beanstalk service role (see [main.tf#L34](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/blob/main/main.tf#L34)).
This PR updates our module to use a dedicated IAM role for the lifecycle policy, preventing a name collision with the existing service role.



## why

* It creates a dedicated iam role for lifecycle policy.
* Prevents conflicts with the service role created by the environment module.

## references

Cloud Posse environment module creating the EB service role: [main.tf#L34](https://github.com/cloudposse/terraform-aws-elastic-beanstalk-environment/blob/main/main.tf#L34)
