### PR TITLE
feat(): expose suffix for lifecycle role to be overwritten

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "service" {
 resource "aws_iam_role" "default" {
   count = local.enabled && var.create_lifecycle_service_role ? 1 : 0
 
-  name               = "${module.this.id}-eb-appversion-lifecycle-service"
+  name               = "${module.this.id}-${var.appversion_lifecycle_service_role_name_suffix}"
   assume_role_policy = join("", data.aws_iam_policy_document.service[*].json)
   tags               = module.this.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "create_lifecycle_service_role" {
   description = "Whether to create service role for application version cleanup. If set, `appversion_lifecycle_service_role_arn` will be ignored"
 }
 
+variable "appversion_lifecycle_service_role_name_suffix" {
+  type        = string
+  default     = "eb-appversion-lifecycle-service"
+  description = "Suffix to add to the lifecycle service role name."
+}
+
 variable "prefer_legacy_service_policy" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what

The default eb lifecycle role is long if you have a long application name.

## why

Allowing it to be overritten, it fixes the 64 chars limit size.

<img width="1268" height="146" alt="image" src="https://github.com/user-attachments/assets/3f36cba8-2fe0-4d77-9684-5aae3c7bb880" />


